### PR TITLE
Scale sprites and enable fullscreen mode

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -6,8 +6,8 @@ pour un rendu pixel‑perfect sans flou.
 
 from __future__ import annotations
 
-import os
 import sys
+from pathlib import Path
 import pygame
 
 from settings import (
@@ -19,6 +19,7 @@ from settings import (
     FPS,
     BACKGROUND_IMG,
     MUSIC_FILE,
+    FULLSCREEN,
 )
 from player import Player
 
@@ -31,21 +32,22 @@ def main() -> None:
     pygame.display.set_caption("47 Ronins Chats – Prototype")
 
    # Fenêtre et surface de rendu pixelisée
-    window = pygame.display.set_mode((DISPLAY_WIDTH, DISPLAY_HEIGHT))
+    flags = pygame.FULLSCREEN if FULLSCREEN else 0
+    window = pygame.display.set_mode((DISPLAY_WIDTH, DISPLAY_HEIGHT), flags)
     canvas = pygame.Surface((WINDOW_WIDTH, WINDOW_HEIGHT)).convert()
     clock = pygame.time.Clock()
 
 
-    # Gestion des chemins
-    script_dir = os.path.dirname(__file__)
-    music_path = os.path.join(script_dir, r"../assets/son/Music1.wav")
-    background_path = os.path.join(script_dir, BACKGROUND_IMG)
+    # Chemins absolus des assets
+    music_path = Path(MUSIC_FILE)
+    background_path = Path(BACKGROUND_IMG)
 
     # Chargement audio + image
-    pygame.mixer.music.load(music_path)
+    pygame.mixer.music.load(str(music_path))
     pygame.mixer.music.play(-1)
 
-    background = pygame.image.load(background_path).convert()
+    background = pygame.image.load(str(background_path)).convert()
+    background = pygame.transform.scale(background, (WINDOW_WIDTH, WINDOW_HEIGHT))
 
  
     # Entités

--- a/src/player.py
+++ b/src/player.py
@@ -14,6 +14,7 @@ from settings import (
     GRAVITY,
     JUMP_SPEED,
     WINDOW_HEIGHT,
+    PLAYER_SCALE,
     PLAYER_STAND_IMG,
     PLAYER_WALK_IMG,
     PLAYER_JUMP_IMG,
@@ -34,18 +35,24 @@ class Player:
 
     def __init__(self, pos: tuple[int, int]):
         self.images = {
-            "stand": pygame.image.load(PLAYER_STAND_IMG).convert_alpha(),
-            "walk": pygame.image.load(PLAYER_WALK_IMG).convert_alpha(),
-            "jump": pygame.image.load(PLAYER_JUMP_IMG).convert_alpha(),
-            "sit": pygame.image.load(PLAYER_SIT_IMG).convert_alpha(),
+            "stand": pygame.image.load(str(PLAYER_STAND_IMG)).convert_alpha(),
+            "walk": pygame.image.load(str(PLAYER_WALK_IMG)).convert_alpha(),
+            "jump": pygame.image.load(str(PLAYER_JUMP_IMG)).convert_alpha(),
+            "sit": pygame.image.load(str(PLAYER_SIT_IMG)).convert_alpha(),
         }
+
+        # Réduction des sprites pour une taille adaptée à l'écran
+        for key, img in self.images.items():
+            w = int(img.get_width() * PLAYER_SCALE)
+            h = int(img.get_height() * PLAYER_SCALE)
+            self.images[key] = pygame.transform.scale(img, (w, h))
         self.current_image = self.images["stand"]
         width, height = self.current_image.get_size()
         self.rect = pygame.Rect(pos[0], pos[1], width, height)
         self.vel = pygame.Vector2(0, 0)
         self.on_ground = False
         self.facing_left = False
-        self.jump_sound = pygame.mixer.Sound(JUMP_SOUND_FILE)
+        self.jump_sound = pygame.mixer.Sound(str(JUMP_SOUND_FILE))
 
     # ————————————————————
     # Boucle d’update

--- a/src/settings.py
+++ b/src/settings.py
@@ -3,7 +3,7 @@ Définit toutes les constantes de configuration du jeu : dimensions d’écran,
 Ce fichier centralise les paramètres pour simplifier les ajustements ultérieurs.
 """
 
-import pygame
+from pathlib import Path
 
 # —— Dimensions d’origine (pixel‑art) ——
 WINDOW_WIDTH: int = 320
@@ -17,6 +17,12 @@ DISPLAY_HEIGHT: int = WINDOW_HEIGHT * UPSCALE
 SKY_BLUE: tuple[int, int, int] = (92, 148, 252)  # Fond provisoire
 PLAYER_RED: tuple[int, int, int] = (222, 68, 55)
 
+# Taille du joueur (facteur de réduction des sprites d'origine)
+PLAYER_SCALE: float = 0.0625  # 1024px -> 64px environ
+
+# Mode plein écran
+FULLSCREEN: bool = True
+
 # —— Physique du joueur ——
 FPS: int = 60
 PLAYER_SPEED: float = 2.5  # Vitesse horizontale en px par frame (avant upscale)
@@ -27,12 +33,15 @@ JUMP_SPEED: float = -6.5   # Impulsion verticale du saut (négatif = vers le hau
 GROUND_Y: int = WINDOW_HEIGHT  # Limite inférieure (sol) pour collision simple
 
 # —— Assets ——
-BACKGROUND_IMG: str = "../assets/niveaux/background_forest.png"
-MUSIC_FILE: str = "../assets/son/Music1.wav"
-JUMP_SOUND_FILE: str = "../assets/son/386529__glennm__breathing_jumping.wav"
-PLAYER_STAND_IMG: str = "../assets/personnages/oishi_stand.png"
-PLAYER_WALK_IMG: str = "../assets/personnages/oishi_walk.png"
-PLAYER_JUMP_IMG: str = "../assets/personnages/oishi_jump.png"
-PLAYER_SIT_IMG: str = "../assets/personnages/oishi_sit.png"
+BASE_DIR: Path = Path(__file__).resolve().parent.parent
+ASSETS_DIR: Path = BASE_DIR / "assets"
+
+BACKGROUND_IMG: Path = ASSETS_DIR / "niveaux" / "background_forest.png"
+MUSIC_FILE: Path = ASSETS_DIR / "son" / "Music1.wav"
+JUMP_SOUND_FILE: Path = ASSETS_DIR / "son" / "386529__glennm__breathing_jumping.wav"
+PLAYER_STAND_IMG: Path = ASSETS_DIR / "personnages" / "oishi_stand.png"
+PLAYER_WALK_IMG: Path = ASSETS_DIR / "personnages" / "oishi_walk.png"
+PLAYER_JUMP_IMG: Path = ASSETS_DIR / "personnages" / "oishi_jump.png"
+PLAYER_SIT_IMG: Path = ASSETS_DIR / "personnages" / "oishi_sit.png"
 
 


### PR DESCRIPTION
## Summary
- update settings to use pathlib and constants for scaling/fullscreen
- resize loaded player sprites
- resize background to window size and open fullscreen
- reference assets with absolute paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684f368a0fd8832d82c56c2b7d1f166f