### PR TITLE
Remove fullscreen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # 47_ronins
 Jeu sidescroller 47_ronin
+
+## Configuration
+
+Les paramètres du jeu sont définis dans [`src/settings.py`](src/settings.py). Le jeu
+démarre désormais en mode fenêtré par défaut (`FULLSCREEN = False`).

--- a/src/settings.py
+++ b/src/settings.py
@@ -21,7 +21,7 @@ PLAYER_RED: tuple[int, int, int] = (222, 68, 55)
 PLAYER_SCALE: float = 0.0625  # 1024px -> 64px environ
 
 # Mode plein écran
-FULLSCREEN: bool = True
+FULLSCREEN: bool = False
 
 # —— Physique du joueur ——
 FPS: int = 60


### PR DESCRIPTION
## Summary
- disable fullscreen mode by default in settings
- document this change in README

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f38635d34832d814860ab2e0fb9a1