### PR TITLE
Ajout animation saut et attaque, points de vie et plateforme

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -52,6 +52,13 @@ def main() -> None:
  
     # Entités
     player = Player((WINDOW_WIDTH // 2, WINDOW_HEIGHT - 20))
+    platform = pygame.Rect(WINDOW_WIDTH // 4, WINDOW_HEIGHT - 60, 80, 10)
+
+    # Petit sprite pour les coeurs
+    heart = pygame.Surface((12, 10), pygame.SRCALPHA)
+    pygame.draw.circle(heart, (255, 0, 0), (3, 3), 3)
+    pygame.draw.circle(heart, (255, 0, 0), (9, 3), 3)
+    pygame.draw.polygon(heart, (255, 0, 0), [(0, 5), (12, 5), (6, 9)])
 
     # Boucle principale
     running = True
@@ -59,12 +66,16 @@ def main() -> None:
         for event in pygame.event.get():
             if event.type == pygame.QUIT:
                 running = False
+            elif event.type == pygame.KEYDOWN and event.key == pygame.K_f:
+                player.start_attack()
 
         pressed = pygame.key.get_pressed()
-        player.update(pressed)
+        player.update(pressed, [platform])
 
         canvas.blit(background, (0, 0))
+        pygame.draw.rect(canvas, (139, 69, 19), platform)
         player.draw(canvas)
+        player.draw_health(canvas, heart)
 
         pygame.transform.scale(canvas, (DISPLAY_WIDTH, DISPLAY_HEIGHT), window)
         pygame.display.flip()

--- a/src/settings.py
+++ b/src/settings.py
@@ -43,5 +43,6 @@ PLAYER_STAND_IMG: Path = ASSETS_DIR / "personnages" / "oishi_stand.png"
 PLAYER_WALK_IMG: Path = ASSETS_DIR / "personnages" / "oishi_walk.png"
 PLAYER_JUMP_IMG: Path = ASSETS_DIR / "personnages" / "oishi_jump.png"
 PLAYER_SIT_IMG: Path = ASSETS_DIR / "personnages" / "oishi_sit.png"
+PLAYER_ATTACK_IMG: Path = ASSETS_DIR / "personnages" / "Oishi-attac.png"
 
 


### PR DESCRIPTION
## Notes
- Ajout des sprites pour les animations de saut et d’attaque.
- Implémentation d’un système de points de vie avec 5 cœurs affichés en haut à gauche.
- Ajout d’une plateforme et blocage du joueur sur le bord gauche de l’écran.
- Nouvelle entrée clavier `F` pour déclencher l’attaque.

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851dd664fec832dbe154027f4f7398d