### PR TITLE
Fix jump animations and improve pause menu

### DIFF
--- a/src/enemy.py
+++ b/src/enemy.py
@@ -12,6 +12,8 @@ class Enemy:
     attack_path: Path | None = None
     health: int = 1
 
+    facing_left: bool = True
+
     hitbox: pygame.Rect | None = None
     attacking: bool = False
     attack_timer: int = 0
@@ -30,6 +32,8 @@ class Enemy:
 
     def draw(self, surface: pygame.Surface) -> None:
         img = self.attack_image if self.attacking else self.image
+        if not self.facing_left:
+            img = pygame.transform.flip(img, True, False)
         surface.blit(img, self.rect)
 
     def take_damage(self, amount: int) -> None:
@@ -47,6 +51,7 @@ class Enemy:
         if abs(player_rect.centerx - self.hitbox.centerx) < 40 and abs(player_rect.centery - self.hitbox.centery) < self.hitbox.height:
             self.attacking = True
             self.attack_timer = 20
+            self.facing_left = player_rect.centerx < self.hitbox.centerx
 
     def get_attack_rect(self) -> pygame.Rect | None:
         if not self.attacking or self.attack_timer > 10:
@@ -54,5 +59,8 @@ class Enemy:
         width = 16
         height = self.hitbox.height // 2
         y = self.hitbox.centery - height // 2
-        x = self.hitbox.left - width
+        if self.facing_left:
+            x = self.hitbox.left - width
+        else:
+            x = self.hitbox.right
         return pygame.Rect(x, y, width, height)

--- a/src/main.py
+++ b/src/main.py
@@ -125,9 +125,22 @@ def main() -> None:
         "next": pygame.K_e,   # R
         "prev": pygame.K_r,   # L
     }
+    keys = [
+        "up",
+        "down",
+        "left",
+        "right",
+        "attack",
+        "kick",
+        "special",
+        "jump",
+        "prev",
+        "next",
+    ]
 
     menu_open = True
     waiting_key: str | None = None
+    selected_key = 0
     music_volume = 1.0
     sfx_volume = 1.0
 
@@ -150,22 +163,21 @@ def main() -> None:
                         sfx_volume = max(0.0, sfx_volume - 0.1)
                     elif event.key == pygame.K_d:
                         sfx_volume = min(1.0, sfx_volume + 0.1)
-                    elif event.key == pygame.K_l:
-                        waiting_key = "left"
-                    elif event.key == pygame.K_r:
-                        waiting_key = "right"
-                    elif event.key == pygame.K_j:
-                        waiting_key = "jump"
-                    elif event.key == pygame.K_f:
-                        waiting_key = "attack"
-                    elif event.key == pygame.K_d:
-                        waiting_key = "kick"
-                    elif event.key == pygame.K_x:
-                        waiting_key = "special"
-                    elif event.key == pygame.K_e:
-                        waiting_key = "next"
-                    elif event.key == pygame.K_q:
-                        waiting_key = "prev"
+                    elif event.key in (pygame.K_LEFT, pygame.K_RIGHT, pygame.K_UP, pygame.K_DOWN):
+                        cols = 5
+                        row = selected_key // cols
+                        col = selected_key % cols
+                        if event.key == pygame.K_LEFT and col > 0:
+                            col -= 1
+                        elif event.key == pygame.K_RIGHT and col < cols - 1 and row * cols + col + 1 < len(keys):
+                            col += 1
+                        elif event.key == pygame.K_UP and row > 0:
+                            row -= 1
+                        elif event.key == pygame.K_DOWN and (row + 1) * cols + col < len(keys):
+                            row += 1
+                        selected_key = row * cols + col
+                    elif event.key == pygame.K_RETURN:
+                        waiting_key = keys[selected_key]
                 elif menu_open and waiting_key:
                     controls[waiting_key] = event.key
                     waiting_key = None
@@ -241,13 +253,13 @@ def main() -> None:
             snes = pygame.transform.scale(snes, (120, 60))
             canvas.blit(snes, (20, vol_y + 30))
 
-            keys = ["up", "down", "left", "right", "attack", "kick", "special", "jump", "prev", "next"]
             key_y = vol_y + 100
             box_w = 20
             for i, k in enumerate(keys):
                 x = 20 + (i % 5) * 60
                 y = key_y + (i // 5) * 30
-                pygame.draw.rect(canvas, (200, 200, 200), (x, y, box_w, box_w), 1)
+                color = (255, 0, 0) if i == selected_key else (200, 200, 200)
+                pygame.draw.rect(canvas, color, (x, y, box_w, box_w), 1)
                 name = pygame.key.name(controls[k])
                 txt = font.render(name, True, (255, 255, 255))
                 canvas.blit(txt, (x + box_w + 4, y))

--- a/src/player.py
+++ b/src/player.py
@@ -187,6 +187,7 @@ class Player:
             self.vel.y = JUMP_SPEED
             self.on_ground = False
             self.jump_phase = "start"
+            self.frame_index = 0
             self.jump_sound.play()
 
     def apply_gravity(self) -> None:
@@ -277,7 +278,7 @@ class Player:
 
         just_landed = not prev_on_ground and self.on_ground
         if just_landed:
-            if "stand" in self.images:
+            if not self.is_attacking and "stand" in self.images:
                 self.current_image = self.images["stand"]
             self.jump_phase = "stand"
 


### PR DESCRIPTION
## Summary
- tweak jump start to reset animation index
- keep current attack image when landing mid-attack
- flip tengu attack depending on player position
- allow menu navigation with arrow keys and Enter

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685486a0e9cc832d9c8d5876f36d3936