### PR TITLE
Fix missing sound asset path

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -44,7 +44,9 @@ JUMP_SOUND_FILE: Path = ASSETS_DIR / "son" / "son_saut.wav"
 PUNCH_SOUND_FILE: Path = ASSETS_DIR / "son" / "punch1.wav"
 KICK_SOUND_FILE: Path = ASSETS_DIR / "son" / "kick1.wav"
 SWORD_SOUND_FILE: Path = ASSETS_DIR / "son" / "sword-attac1.wav"
-TENGU_HURT_FILE: Path = ASSETS_DIR / "son" / "tengu_hurt.wma"
+# Le fichier "tengu_hurt.wma" a été remplacé par "Tengu_hurt.wav" dans les assets.
+# On met à jour le chemin pour éviter une erreur de chargement.
+TENGU_HURT_FILE: Path = ASSETS_DIR / "son" / "Tengu_hurt.wav"
 
 CHARACTER_DIR: Path = ASSETS_DIR / "personnages"
 OISHI_DIR: Path = CHARACTER_DIR / "1_Oishi_Samourai"


### PR DESCRIPTION
## Summary
- fix TENGU_HURT_FILE path to match the existing WAV file

## Testing
- `python3 -m py_compile src/main.py src/settings.py`


------
https://chatgpt.com/codex/tasks/task_e_6855edd3091c832db49926f71d52cd82