### PR TITLE
Implement sprite sheet animations

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -15,10 +15,12 @@ DISPLAY_HEIGHT: int = WINDOW_HEIGHT * UPSCALE
 
 # —— Couleurs ——
 SKY_BLUE: tuple[int, int, int] = (92, 148, 252)  # Fond provisoire
-PLAYER_RED: tuple[int, int, int] = (222, 68, 55)
 
 # Taille du joueur (facteur de réduction des sprites d'origine)
 PLAYER_SCALE: float = 0.0625  # 1024px -> 64px environ
+
+# Taille d'une frame dans les sprite sheets avant réduction
+SPRITE_SIZE: int = 256
 
 # Mode plein écran
 FULLSCREEN: bool = False


### PR DESCRIPTION
## Summary
- add `SPRITE_SIZE` to settings
- split sprite sheets into frames and animate the player
- clean up unused color constant

## Testing
- `python3 -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_684f39392314832d8dc42489bd4d24f7