### PR TITLE
Update platform collision logic

### DIFF
--- a/src/player.py
+++ b/src/player.py
@@ -271,16 +271,19 @@ class Player:
                 prev_bottom = self.hitbox.bottom - move_y
 
                 will_cross = self.vel.y >= 0 and prev_bottom <= plat.top < self.hitbox.bottom
+                overlap = self.hitbox.right > plat.left and self.hitbox.left < plat.right
 
-                if will_cross:
+                if will_cross and overlap:
                     self.hitbox.bottom = plat.top
                     self.vel.y = 0
                     self.on_ground = True
+                    break
 
-                elif abs(self.hitbox.bottom - plat.top) <= 1 and self.vel.y >= 0:
+                elif abs(self.hitbox.bottom - plat.top) <= 1 and self.vel.y >= 0 and overlap:
                     self.hitbox.bottom = plat.top
                     self.vel.y = 0
                     self.on_ground = True
+                    break
 
         just_landed = not prev_on_ground and self.on_ground
         if just_landed:


### PR DESCRIPTION
## Summary
- restrict landing on platforms to times when the player overlaps horizontally
- exit platform loop once landing is registered

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685732493a7c832db3ce4e815cabfc0f