### PR TITLE
Améliore la résolution par défaut

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,5 +3,6 @@ Jeu sidescroller 47_ronin
 
 ## Configuration
 
-Les paramètres du jeu sont définis dans [`src/settings.py`](src/settings.py). Le jeu
-démarre désormais en mode fenêtré par défaut (`FULLSCREEN = False`).
+Les paramètres du jeu sont définis dans [`src/settings.py`](src/settings.py).
+La résolution est à présent de 1280×960 (320×240 mis à l'échelle ×4).
+Le jeu démarre en mode fenêtré par défaut (`FULLSCREEN = False`).

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,6 @@
 """main.py
 Point d’entrée du jeu : initialisation de Pygame, création de la fenêtre, boucle principale.
-La scène est dessinée sur une surface 320×240 puis mise à l’échelle x3 → 960×720
+La scène est dessinée sur une surface 320×240 puis mise à l’échelle x4 → 1280×960
 pour un rendu pixel‑perfect sans flou.
 """
 

--- a/src/settings.py
+++ b/src/settings.py
@@ -8,7 +8,8 @@ from pathlib import Path
 # —— Dimensions d’origine (pixel‑art) ——
 WINDOW_WIDTH: int = 320
 WINDOW_HEIGHT: int = 240
-UPSCALE: int = 3  # Facteur de mise à l’échelle (320×240 → 960×720)
+# Augmente le facteur de mise à l'échelle pour une résolution plus élevée.
+UPSCALE: int = 4  # 320×240 → 1280×960
 
 DISPLAY_WIDTH: int = WINDOW_WIDTH * UPSCALE
 DISPLAY_HEIGHT: int = WINDOW_HEIGHT * UPSCALE


### PR DESCRIPTION
## Notes
- Resolution factor in `settings.py` increased from 3 to 4
- Docstring in `main.py` updated accordingly
- README updated with new default resolution
- `py_compile` used to check syntax


------
https://chatgpt.com/codex/tasks/task_e_6858530f7a48832da305b9ae14972a0e