### PR TITLE
Add Isamu NPC with recruitment and falling Tengu

### DIFF
--- a/src/npc.py
+++ b/src/npc.py
@@ -1,0 +1,20 @@
+from dataclasses import dataclass
+from pathlib import Path
+import pygame
+from settings import PLAYER_SCALE
+
+@dataclass
+class NPC:
+    """Simple non-playable character displayed in the level."""
+
+    pos: tuple[int, int]
+    image_path: Path
+
+    def __post_init__(self) -> None:
+        img = pygame.image.load(str(self.image_path)).convert_alpha()
+        scale = int(img.get_width() * PLAYER_SCALE)
+        self.image = pygame.transform.scale(img, (scale, scale))
+        self.rect = self.image.get_rect(midbottom=self.pos)
+
+    def draw(self, surface: pygame.Surface, offset_x: int = 0) -> None:
+        surface.blit(self.image, self.rect.move(-offset_x, 0))

--- a/src/settings.py
+++ b/src/settings.py
@@ -38,7 +38,10 @@ GROUND_Y: int = WINDOW_HEIGHT  # Limite inférieure (sol) pour collision simple
 BASE_DIR: Path = Path(__file__).resolve().parent.parent
 ASSETS_DIR: Path = BASE_DIR / "assets"
 
-BACKGROUND_IMG: Path = ASSETS_DIR / "niveaux" / "background_forest.png"
+# L'image d'arrière‑plan du premier stage provient maintenant du dossier
+# "Exemple" ajouté récemment.  Cela permet d'obtenir le rendu souhaité par
+# l'auteur.
+BACKGROUND_IMG: Path = BASE_DIR / "Exemple" / "background_stage_1.png"
 BACKGROUND_IMG_2: Path = ASSETS_DIR / "niveaux" / "background_forest2.png"
 TILESET_IMG: Path = ASSETS_DIR / "niveaux" / "tileset_forest.png"
 PLATFORM_TILESET_IMG: Path = ASSETS_DIR / "niveaux" / "tileset_plateform_1.png"


### PR DESCRIPTION
## Summary
- load custom stage background from `Exemple/background_stage_1.png`
- give enemies gravity so a Tengu can drop onto a platform
- expand patrol range and spawn the second Tengu above the platform
- introduce an `NPC` helper class and add Isamu to the stage
- allow Oishi to recruit Isamu with the kick button, triggering dialog
- end the stage when the player reaches the right edge

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858762e8d4c832d97718559c54aedb2