### PR TITLE
Fix initial level layout to avoid black screen

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -71,13 +71,13 @@ def main() -> None:
     background = pygame.transform.scale(background, (WINDOW_WIDTH, WINDOW_HEIGHT))
     background2 = pygame.image.load(str(background2_path)).convert()
     background2 = pygame.transform.scale(background2, (WINDOW_WIDTH, WINDOW_HEIGHT))
-    # Reuse the first background for the third screen for now
-    background3 = background.copy()
+    # Precompute alternating backgrounds to cover the whole level
+    level_width = WINDOW_WIDTH * 3
+    num_screens = level_width // WINDOW_WIDTH
+    backgrounds = [background if i % 2 == 0 else background2 for i in range(num_screens)]
 
     platforms = create_level_platforms()
     ladders = create_level_ladders(platforms)
-
-    level_width = 1920
 
     tileset = pygame.image.load(str(TILESET_IMG)).convert_alpha()
     tile = tileset.subsurface(pygame.Rect(0, 0, 32, 32))
@@ -116,8 +116,8 @@ def main() -> None:
     }
 
     players = [
-        Player((1728, 120), oishi_assets, name="Oishi"),
-        Player((1728, 120), koji_assets, name="Koji"),
+        Player((40, WINDOW_HEIGHT - 20), oishi_assets, name="Oishi"),
+        Player((40, WINDOW_HEIGHT - 20), koji_assets, name="Koji"),
     ]
     current_player = 0
 
@@ -132,19 +132,24 @@ def main() -> None:
     stage_timer = 0
 
 
-    enemy_positions = [
-        (64, 223),
-        (176, 189),
-        (496, 154),
-        (576, 189),
-        (656, 120),
-        (1056, 34),
-        (1472, 120),
-    ]
-    enemies = [
-        Enemy((x, y), ENEMY_DIR / "Tengu_stand_left.png", ENEMY_DIR / "Tengu_attac.png")
-        for x, y in enemy_positions
-    ]
+    enemy = Enemy(
+        (WINDOW_WIDTH // 2 - 40, WINDOW_HEIGHT),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=WINDOW_WIDTH // 2 - 100,
+        patrol_right=WINDOW_WIDTH // 2 + 100,
+    )
+
+    # Second Tengu placed on the highest platform
+    plat = platforms[-1]
+    enemy2 = Enemy(
+        (plat.rect.centerx, plat.rect.top - 80),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=plat.rect.left - 50,
+        patrol_right=plat.rect.right + 50,
+    )
+    enemies = [enemy, enemy2]
 
     heart_img = pygame.image.load(str(HEART_IMG)).convert_alpha()
     heart_scale = int(heart_img.get_width() * 0.012)
@@ -318,9 +323,8 @@ def main() -> None:
                 stage_complete = True
                 stage_timer = 120
 
-        canvas.blit(background, (-camera_x, 0))
-        canvas.blit(background2, (WINDOW_WIDTH - camera_x, 0))
-        canvas.blit(background3, (2 * WINDOW_WIDTH - camera_x, 0))
+        for i, bg in enumerate(backgrounds):
+            canvas.blit(bg, (i * WINDOW_WIDTH - camera_x, 0))
         for x in range(0, level_width, tile.get_width()):
             canvas.blit(tile, (x - camera_x, WINDOW_HEIGHT - tile.get_height()))
         for plat in platforms:

--- a/src/platforms.py
+++ b/src/platforms.py
@@ -58,63 +58,48 @@ def load_ladder_image() -> pygame.Surface:
     return img
 
 
-def load_stair_image() -> pygame.Surface:
-    """Load and scale the wooden stair sprite."""
-    path = ASSETS_DIR / "niveaux" / "Stair_wood_1.png"
-    img = pygame.image.load(str(path)).convert_alpha()
-    w, h = img.get_size()
-    img = pygame.transform.scale(img, (int(w * PLAYER_SCALE), int(h * PLAYER_SCALE)))
-    return img
-
-
 def create_level_platforms() -> list[Platform]:
-    """Create all platforms for the level following the reference layout."""
-    base = load_platform_image()
-    stair_src = load_stair_image()
-
+    """Create all platforms for the level."""
+    img = load_platform_image()
     platforms: list[Platform] = []
 
-    def add_platform(tiles: int, x: int, bottom: int) -> None:
-        width = base.get_width() * tiles
-        img = pygame.transform.scale(base, (width, base.get_height()))
-        rect = img.get_rect(midbottom=(x, bottom))
-        platforms.append(Platform(rect, img))
+    # --- Screen 1 ---
+    # Small platform near the start
+    # The hero must be able to reach this first platform with a jump.  With the
+    # current physics the maximum jump height is roughly 60 px, so we place the
+    # platform slightly lower than before to keep it within reach.
+    rect1 = img.get_rect(midbottom=(80, WINDOW_HEIGHT - 52))
+    platforms.append(Platform(rect1, img))
 
-    # Bottom left small platform
-    add_platform(2, 160, 206)
+    # Higher platform reached using a ladder
+    rect2 = img.get_rect(midbottom=(160, WINDOW_HEIGHT - 100))
+    platforms.append(Platform(rect2, img))
 
-    # Central mid platform with torii
-    add_platform(2, 480, 171)
+    # --- Screen 2 ---
+    rect3 = img.get_rect(midbottom=(WINDOW_WIDTH + 120, WINDOW_HEIGHT - 70))
+    platforms.append(Platform(rect3, img))
 
-    # Upper left platform reached by the stairs
-    add_platform(2, 640, 137)
-
-    # Large upper right platform
-    add_platform(5, 1344, 137)
-
-    # Stairs descending to the left (10 steps)
-    steps = 10
-    step_w = (640 - 448) // steps or 1
-    step_h = (223 - 137) // steps or 1
-    for i in range(steps):
-        img = pygame.transform.scale(stair_src, (step_w, step_h))
-        x = 640 - i * step_w
-        bottom = 137 + (i + 1) * step_h
-        rect = img.get_rect(midbottom=(x, bottom))
-        platforms.append(Platform(rect, img))
+    rect4 = img.get_rect(midbottom=(WINDOW_WIDTH + 200, WINDOW_HEIGHT - 120))
+    platforms.append(Platform(rect4, img))
 
     return platforms
 
 
 def create_level_ladders(platforms: list[Platform]) -> list[Ladder]:
     """Create ladders for the level."""
-    raw = load_ladder_image()
+    img = load_ladder_image()
     ladders: list[Ladder] = []
 
-    # Rope ladder on the far right platform
-    height = int(WINDOW_HEIGHT - 154)
-    img = pygame.transform.scale(raw, (raw.get_width(), height))
-    rect = img.get_rect(midbottom=(1664, WINDOW_HEIGHT))
-    ladders.append(Ladder(rect, img))
+    # Ladder from platform 1 to platform 2
+    if len(platforms) >= 2:
+        upper = platforms[1]
+        rect = img.get_rect(midbottom=(upper.rect.centerx, upper.rect.top))
+        ladders.append(Ladder(rect, img))
+
+    # Ladder leading to the highest platform
+    if len(platforms) >= 4:
+        high = platforms[3]
+        rect2 = img.get_rect(midbottom=(high.rect.centerx, high.rect.top))
+        ladders.append(Ladder(rect2, img))
 
     return ladders


### PR DESCRIPTION
## Summary
- restore level width to three screens and precompute backgrounds to match
- reposition starting players at the first screen
- restore initial enemy placements
- simplify platform layout and ladders

## Testing
- `python -m py_compile src/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6862f50aa754832dbe7803dbf44e1d68