### PR TITLE
Fix level layout and enemy count

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -34,7 +34,11 @@ from settings import (
 )
 from player import Player
 from enemy import Enemy
-from platforms import create_level_platforms, create_level_ladders
+from platforms import (
+    create_level_platforms,
+    create_level_ladders,
+    create_level_stairs,
+)
 from npc import NPC
 
 
@@ -78,6 +82,7 @@ def main() -> None:
 
     platforms = create_level_platforms()
     ladders = create_level_ladders(platforms)
+    stairs = create_level_stairs()
 
     tileset = pygame.image.load(str(TILESET_IMG)).convert_alpha()
     tile = tileset.subsurface(pygame.Rect(0, 0, 32, 32))
@@ -149,7 +154,41 @@ def main() -> None:
         patrol_left=plat.rect.left - 50,
         patrol_right=plat.rect.right + 50,
     )
-    enemies = [enemy, enemy2]
+
+    # Additional Tengu enemies across the stage
+    enemy3 = Enemy(
+        (WINDOW_WIDTH + 60, WINDOW_HEIGHT),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=WINDOW_WIDTH + 20,
+        patrol_right=WINDOW_WIDTH + 100,
+    )
+
+    enemy4 = Enemy(
+        (WINDOW_WIDTH + 200, WINDOW_HEIGHT),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=WINDOW_WIDTH + 160,
+        patrol_right=WINDOW_WIDTH + 240,
+    )
+
+    enemy5 = Enemy(
+        (WINDOW_WIDTH * 2 + 40, WINDOW_HEIGHT),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=WINDOW_WIDTH * 2,
+        patrol_right=WINDOW_WIDTH * 2 + 80,
+    )
+
+    enemy6 = Enemy(
+        (WINDOW_WIDTH * 2 + 160, WINDOW_HEIGHT),
+        ENEMY_DIR / "Tengu_stand_left.png",
+        ENEMY_DIR / "Tengu_attac.png",
+        patrol_left=WINDOW_WIDTH * 2 + 120,
+        patrol_right=WINDOW_WIDTH * 2 + 200,
+    )
+
+    enemies = [enemy, enemy2, enemy3, enemy4, enemy5, enemy6]
 
     heart_img = pygame.image.load(str(HEART_IMG)).convert_alpha()
     heart_scale = int(heart_img.get_width() * 0.012)
@@ -331,6 +370,8 @@ def main() -> None:
             canvas.blit(plat.image, (plat.rect.x - camera_x, plat.rect.y))
         for lad in ladders:
             canvas.blit(lad.image, (lad.rect.x - camera_x, lad.rect.y))
+        for st in stairs:
+            canvas.blit(st.image, (st.rect.x - camera_x, st.rect.y))
         for en in enemies:
             if en.health > 0:
                 en.draw(canvas, camera_x)

--- a/src/platforms.py
+++ b/src/platforms.py
@@ -27,6 +27,14 @@ class Ladder:
     image: pygame.Surface
 
 
+@dataclass
+class Staircase:
+    """Decorative staircase used to reach a higher platform."""
+
+    rect: pygame.Rect
+    image: pygame.Surface
+
+
 def load_platform_image() -> pygame.Surface:
     """Load and return the platform sprite."""
     sheet = pygame.image.load(str(PLATFORM_TILESET_IMG)).convert_alpha()
@@ -35,9 +43,10 @@ def load_platform_image() -> pygame.Surface:
     # down.  The wooden platform graphics sit near the bottom of the sheet but
     # their exact vertical position changed between asset revisions.  To avoid
     # hardcoding a value that might fall outside the image, we compute the
-    # region dynamically using the bottom 64 pixels of the tileset.
+    # region dynamically using the bottom 256 pixels of the tileset to ensure
+    # the scaled image remains visible.
     h = sheet.get_height()
-    region = pygame.Rect(64, max(0, h - 64), 512, 64)
+    region = pygame.Rect(64, max(0, h - 256), 512, 256)
     img = sheet.subsurface(region).copy()
 
     # Scale down using the same factor as the characters for pixel-perfect
@@ -52,6 +61,15 @@ def load_ladder_image() -> pygame.Surface:
     # The asset was renamed from "Echelle.png" to "Echelle_corde.png" in the
     # repository.  Update the path accordingly to avoid a FileNotFoundError.
     path = ASSETS_DIR / "niveaux" / "Echelle_corde.png"
+    img = pygame.image.load(str(path)).convert_alpha()
+    w, h = img.get_size()
+    img = pygame.transform.scale(img, (int(w * PLAYER_SCALE), int(h * PLAYER_SCALE)))
+    return img
+
+
+def load_stair_image() -> pygame.Surface:
+    """Load and scale the wooden staircase sprite."""
+    path = ASSETS_DIR / "niveaux" / "Stair_wood_1.png"
     img = pygame.image.load(str(path)).convert_alpha()
     w, h = img.get_size()
     img = pygame.transform.scale(img, (int(w * PLAYER_SCALE), int(h * PLAYER_SCALE)))
@@ -90,16 +108,22 @@ def create_level_ladders(platforms: list[Platform]) -> list[Ladder]:
     img = load_ladder_image()
     ladders: list[Ladder] = []
 
-    # Ladder from platform 1 to platform 2
-    if len(platforms) >= 2:
-        upper = platforms[1]
-        rect = img.get_rect(midbottom=(upper.rect.centerx, upper.rect.top))
-        ladders.append(Ladder(rect, img))
-
-    # Ladder leading to the highest platform
+    # Single ladder on the far right leading to the highest platform
     if len(platforms) >= 4:
         high = platforms[3]
-        rect2 = img.get_rect(midbottom=(high.rect.centerx, high.rect.top))
-        ladders.append(Ladder(rect2, img))
+        rect = img.get_rect(midbottom=(high.rect.centerx, high.rect.top))
+        ladders.append(Ladder(rect, img))
 
     return ladders
+
+
+def create_level_stairs() -> list[Staircase]:
+    """Create the decorative staircase for the level."""
+    img = load_stair_image()
+    stairs: list[Staircase] = []
+
+    # Place the staircase near the middle of the level
+    rect = img.get_rect(midbottom=(WINDOW_WIDTH + 40, WINDOW_HEIGHT))
+    stairs.append(Staircase(rect, img))
+
+    return stairs


### PR DESCRIPTION
## Summary
- adjust platform tile extraction so platforms are visible
- create a decorative staircase sprite
- place a single ladder on the far right
- add four additional Tengu enemies

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862fa9dfa50832d9a8e7dcffd334ec9