### PR TITLE
Improve Koji jump and lower first wall

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -27,6 +27,7 @@ from settings import (
     KOJI_DIR,
     HEART_IMG,
     SNES_IMG,
+    JUMP_SPEED,
 )
 from player import Player
 
@@ -116,7 +117,12 @@ def main() -> None:
 
     players = [
         Player((40, WINDOW_HEIGHT - 20), oishi_assets, name="Oishi"),
-        Player((40, WINDOW_HEIGHT - 20), koji_assets, name="Koji"),
+        Player(
+            (40, WINDOW_HEIGHT - 20),
+            koji_assets,
+            name="Koji",
+            jump_speed=JUMP_SPEED * 1.2,
+        ),
     ]
     current_player = 0
 

--- a/src/platforms.py
+++ b/src/platforms.py
@@ -89,7 +89,13 @@ def load_wall_image() -> pygame.Surface:
     path = ASSETS_DIR / "niveaux" / "Wall_wood_side.png"
     img = pygame.image.load(str(path)).convert_alpha()
     w, h = img.get_size()
-    img = pygame.transform.scale(img, (int(w * PLAYER_SCALE), int(h * PLAYER_SCALE)))
+    img = pygame.transform.scale(
+        img,
+        (
+            int(w * PLAYER_SCALE),
+            int(h * PLAYER_SCALE * 0.5),
+        ),
+    )
     return img
 
 

--- a/src/player.py
+++ b/src/player.py
@@ -39,11 +39,18 @@ class Player:
     invincible: bool = False
     landing_timer: int = 0
     on_ladder: bool = False
+    jump_speed: float = JUMP_SPEED
 
     attack_type: str = ""
     name: str = "player"
 
-    def __init__(self, pos: tuple[int, int], asset_paths: dict[str, Path], name: str = "player"):
+    def __init__(
+        self,
+        pos: tuple[int, int],
+        asset_paths: dict[str, Path],
+        name: str = "player",
+        jump_speed: float = JUMP_SPEED,
+    ):
         """Initialise le joueur avec les sprites du personnage choisi."""
 
         self.name = name
@@ -81,6 +88,7 @@ class Player:
         self.on_ground = False
         self.facing_left = False
         self.jump_sound = pygame.mixer.Sound(str(JUMP_SOUND_FILE))
+        self.jump_speed = jump_speed
         self.is_attacking = False
         self.attack_type = ""
         self.health = 6 if name.lower() == "koji" else 5
@@ -196,7 +204,7 @@ class Player:
 
         # Saut : possible uniquement quand le joueur est au sol
         if pressed[controls.get("jump", pygame.K_SPACE)] and self.on_ground:
-            self.vel.y = JUMP_SPEED
+            self.vel.y = self.jump_speed
             self.on_ground = False
             self.jump_phase = "start"
             self.frame_index = 0


### PR DESCRIPTION
## Summary
- shorten wooden wall image to let the player hop over it
- allow setting jump speed per player
- bump Koji's jump height for better reach

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6863081d41a4832d8c46823eac92d299